### PR TITLE
feat(hackathon): load hackathon details dynamically based on route id

### DIFF
--- a/frontend/hack-sprint/src/pages/AllHackathons.jsx
+++ b/frontend/hack-sprint/src/pages/AllHackathons.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { useNavigate } from "react-router-dom";
 import Loader from '../components/Loader'
 import { Users, Calendar, Timer, ArrowRight, Code, Trophy, Zap, Star, Github, ExternalLink, Terminal, Coffee, Bug, Lightbulb, Cpu, Database } from 'lucide-react'
 import axios from "axios";
@@ -56,6 +57,7 @@ const TabButton = ({ active, onClick, children, count, icon: Icon }) => (
 )
 
 const HackathonCard = ({ hackathon }) => {
+  const navigate = useNavigate();
   const [isHovered, setIsHovered] = useState(false)
   const [countdown, setCountdown] = useState('')
   const [imageLoaded, setImageLoaded] = useState(false)
@@ -116,6 +118,7 @@ const HackathonCard = ({ hackathon }) => {
         }`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onClick={() => navigate(`/hackathon/${hackathon._id}`)}
     >
       {/* Scan line effect */}
       <div className={`absolute inset-0 bg-gradient-to-r from-transparent via-green-400/20 to-transparent transform -skew-x-12 transition-transform duration-1000 ${isHovered ? 'translate-x-full' : '-translate-x-full'

--- a/frontend/hack-sprint/src/pages/Hackathon.jsx
+++ b/frontend/hack-sprint/src/pages/Hackathon.jsx
@@ -194,6 +194,7 @@ const Loader = () => (
 );
 
 export default function HackathonDetails() {
+  const { id } = useParams(); 
   const [hackathon, setHackathon] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -208,7 +209,8 @@ export default function HackathonDetails() {
       setError("");
       await new Promise((r) => setTimeout(r, 600));
       if (USE_DUMMY_DATA) {
-        const found = dummyHackathons[0];
+        const found = dummyHackathons.find(h => h._id === id); // Find by id
+        if (!found) setError("Hackathon not found!");
         setHackathon(found);
       }
       setLoading(false);


### PR DESCRIPTION
What I did
	• Updated hackathon detail logic to properly search hackathon by _id.
	• Added error handling with a clear message ("Hackathon not found!") when no matching hackathon exists.
